### PR TITLE
Bug: Fotek PL-05N probe

### DIFF
--- a/Octopus works on Voron v2.4/Firmware/Klipper/BTT_OctoPus_Voron2_Config.cfg
+++ b/Octopus works on Voron v2.4/Firmware/Klipper/BTT_OctoPus_Voron2_Config.cfg
@@ -18,6 +18,7 @@
 ## Probe points							[quad_gantry_level] section
 ## Min & Max gantry corner postions		[quad_gantry_level] section
 ## PID tune								[extruder] and [heater_bed] sections
+## Probe pin								[probe] section
 ## Fine tune E steps					[extruder] section
 
 [mcu]

--- a/Octopus works on Voron v2.4/Firmware/Klipper/BTT_OctoPus_Voron2_Config.cfg
+++ b/Octopus works on Voron v2.4/Firmware/Klipper/BTT_OctoPus_Voron2_Config.cfg
@@ -292,7 +292,15 @@ pid_kd: 363.769
 [probe]
 ##	Inductive Probe
 ##	This probe is not used for Z height, only Quad Gantry Leveling
-pin: ~!PB7
+
+# Select the probe port by type:
+## For the PROBE port; use this with the original OMRON sensor.
+# pin: ~!PB7
+## For the spare endstop port; use this with the Fotek PL-05N (or generic) inductive probe
+# pin: ^PG11
+
+#--------------------------------------------------------------------
+
 x_offset: 0
 y_offset: 25.0
 z_offset: 0


### PR DESCRIPTION
When used with a PL-05N probe, the PROBE port doesn't reliably trigger. We should instead use the spare end-stop port (with pull-up) to detect the sensor output.