### PR TITLE
Update pins_BTT_OCTOPUS_V1_common.h

### DIFF
--- a/Firmware/Marlin-bugfix-2.0.x/Marlin/src/pins/stm32f4/pins_BTT_OCTOPUS_V1_common.h
+++ b/Firmware/Marlin-bugfix-2.0.x/Marlin/src/pins/stm32f4/pins_BTT_OCTOPUS_V1_common.h
@@ -443,6 +443,13 @@
     #undef BOARD_ST7920_DELAY_2
     #undef BOARD_ST7920_DELAY_3
 
+   #elif ENABLED(MKS_MINI_12864)  //quick fix for allowing use of MKS12864A/B and MKS_MINI_12864 LCD. See issue #70. Credits for the original work to @Gleb1982
+
+    #define DOGLCD_A0                EXP1_04_PIN
+    #define DOGLCD_CS                EXP1_05_PIN
+    #define BTN_EN1                  EXP2_08_PIN
+    #define BTN_EN2                  EXP2_06_PIN
+
   #else
 
     #define LCD_PINS_RS              EXP1_07_PIN


### PR DESCRIPTION
Introduced a (quick) fix for allowing use of MKS12864A/B and MKS_MINI_12864 LCD. See issue #70. Credits for the original work to @Gleb1982
The only small issue remaining is that FPC cables will need to be inverted (rotated by 180°) when connecting to the motherboard socket. Even tough, it's a trivial issue that mostly are familiar with.