### PR TITLE
Fix to the absurdly low max_z_accel

### DIFF
--- a/Firmware/Klipper/Octopus klipper.cfg
+++ b/Firmware/Klipper/Octopus klipper.cfg
@@ -133,7 +133,7 @@ kinematics: cartesian
 max_velocity: 500
 max_accel: 3000
 max_z_velocity: 12
-max_z_accel: 5
+max_z_accel: 400
 
 ########################################
 # TMC2208 configuration


### PR DESCRIPTION
I have been helping a few people with their printers and keep finding issues relating to this config. The max_z_accel set here is absurdly low, and is so slow that it causes blobs for whenever a layer change is requested by gcode. I have updated it with a more appropriate acceleration, that should be suitable for a leadscrew based z axis. Although it's good practise for people to completely customise their own configurations, not everyone is as experienced as others, and small little settings like these can cause extra unneccesary confusion and troubleshooting.